### PR TITLE
Added option to return a string from restore

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,8 +30,8 @@ module.exports = function captureStream (stream) {
   stream.write = function () {
     output.push([].slice.call(arguments));
   };
-  return function restore () {
+  return function restore (wantString) {
     stream.write = write;
-    return output;
+    return wantString ? output.join('') : output;
   };
 };

--- a/test.js
+++ b/test.js
@@ -17,11 +17,18 @@ describe('capture-stream', function () {
     console.log.apply(console, arguments);
   }
 
-  it('should capture "Hello, world!!!" from stdout', function () {
+  it('should capture "Hello, world!!!" from stdout and return an array when restore is called with no arguments', function () {
     var restore = capture(process.stdout);
     log('Hello, world!!!');
     var output = restore();
     assert.equal(output.length, 1);
     assert(output[0][0].indexOf('Hello, world!!!') === 0);
+  });
+
+  it('should capture "Hello, world!!!" from stdout and return a string when restore is called with a truthy argument', function () {
+    var restore = capture(process.stdout);
+    log('Hello, world!!!');
+    var output = restore(true);
+    assert(output === 'Hello, world!!!\n');
   });
 });


### PR DESCRIPTION
I usually don't care about how many calls were made to `console.log`, so returning an array from `restore` isn't helpful. Of course I can add `.join('')` to the result, but it is much cleaner if there is an added boolean parameter to `restore`, which if truthy, returns a string.
