### PR TITLE
Added power support for the travis.yml file with ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ arch:
   - amd64
   - ppc64le
 node_js:
-  - "0.10"
-  - "0.12"
   - "4.0"
   - "iojs"
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 sudo: false
 language: node_js
+arch:
+  - amd64
+  - ppc64le
 node_js:
-  - "0.10"
-  - "0.12"
+  - "10"
+  - "12"
   - "4.0"
   - "iojs"
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ arch:
   - amd64
   - ppc64le
 node_js:
-  - "10"
-  - "12"
+  - "0.10"
+  - "0.12"
   - "4.0"
   - "iojs"
 matrix:


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. 
This helps us simplify testing later when distributions are re-building and re-releasing.
